### PR TITLE
Refresh Token Support & Auth Restructure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,18 +30,18 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow = "19.0.0"
-arrow-flight = "19.0.0"
-azure_core = "0.3.0"
-azure_identity = "0.4.0"
+arrow = "20.0.0"
+arrow-flight = "20.0.0"
+azure_core = "0.4.0"
+azure_identity = "0.5.0"
 chrono = "0.4.20"
 clap = { version = "3.2.13", features = ["derive"] }
 confy = "0.4.0"
 futures = "0.3.21"
 http = "0.2.8"
 oauth2 = "4.2.3"
-parquet = { version = "19.0.0", features = ["async"] }
+parquet = { version = "20.0.0", features = ["async"] }
 serde = { version = "1.0.140", features = ["derive"] }
 tokio = { version = "1.20.0", features = ["tokio-macros", "net"] }
-tonic = { version = "0.7.2", features = ["tls", "tls-roots"] } # TODO: Update this to 0.8.0 when arrow updates to 20.0.0
+tonic = { version = "0.8.0", features = ["tls", "tls-roots"] }
 url = "2.2.2"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -74,7 +74,9 @@ pub async fn authorize(
     } else {
         let refresh_token = stored_token.1;
         match identity_provider {
-            IdentityProvider::Azure => Ok(azure::azure_authorize(scope.to_string(), refresh_token).await?),
+            IdentityProvider::Azure => {
+                Ok(azure::azure_authorize(scope.to_string(), refresh_token).await?)
+            }
             _ => Err(Box::new(CliError::new(
                 "Identity Provider not currently implemented!".to_string(),
             ))),
@@ -98,7 +100,7 @@ fn check_stored_token(
 }
 
 fn store_access_token(
-    access_token: AccessToken,
+    access_token: &AccessToken,
     expires_in: Option<core::time::Duration>,
     refresh_token: Option<&RefreshToken>,
     id_provider: IdentityProvider,
@@ -112,14 +114,14 @@ fn store_access_token(
     };
     let new_store = if let Some(refresh_token) = refresh_token {
         AuthStore {
-            token: access_token,
+            token: access_token.to_owned(),
             expiry_time,
             identity_provider: id_provider,
             refresh_token: refresh_token.to_owned(),
         }
     } else {
         AuthStore {
-            token: access_token,
+            token: access_token.to_owned(),
             expiry_time,
             identity_provider: id_provider,
             refresh_token: RefreshToken::new("".to_string()),

--- a/src/auth/azure.rs
+++ b/src/auth/azure.rs
@@ -1,0 +1,81 @@
+use crate::auth::store_access_token;
+use crate::IdentityProvider;
+use azure_identity::{authorization_code_flow, development};
+use oauth2::{AccessToken, ClientId, RefreshToken, TokenResponse};
+use std::env;
+use std::error::Error;
+use url::Url;
+
+pub async fn azure_authorize(
+    scope: String,
+    refresh_token: Option<RefreshToken>,
+) -> Result<AccessToken, Box<dyn Error>> {
+    let client_id = ClientId::new(
+        env::var("OAUTH_CLIENT_ID").expect("Missing CLIENT_ID environment variable."),
+    );
+    let tenant_id = env::var("AZURE_TENANT_ID").expect("Missing TENANT_ID environment variable.");
+    if let Some(refresh_token) = refresh_token {
+        let token = azure_refresh_authorization(&refresh_token, &client_id, &tenant_id).await;
+        match token {
+            Ok(token) => return Ok(token),
+            Err(e) => eprintln!("{}", e),
+        }
+    }
+    Ok(azure_browser_authorization(scope, client_id, tenant_id).await?)
+}
+
+async fn azure_browser_authorization(
+    scope: String,
+    client_id: ClientId,
+    tenant_id: String,
+) -> Result<AccessToken, Box<dyn Error>> {
+    let scope = format!("{} offline_access", scope);
+
+    let c = authorization_code_flow::start(
+        client_id,
+        None,
+        &tenant_id,
+        Url::parse("http://localhost:47471")?,
+        &*scope,
+    );
+    println!("\nOpen this URL in a browser:\n{}", c.authorize_url);
+
+    // Using a naive, blocking redirect server is fine for our case, as it should block anyway
+    let code = development::naive_redirect_server(&c, 47471)?;
+
+    // Exchange the token with one that can be used for authorization
+    let tr = c.exchange(code).await?;
+    store_access_token(
+        tr.access_token().to_owned(),
+        tr.expires_in(),
+        tr.refresh_token(),
+        IdentityProvider::Azure,
+    )?;
+    Ok(tr.access_token().to_owned())
+}
+
+async fn azure_refresh_authorization(
+    refresh_token: &RefreshToken,
+    client_id: &ClientId,
+    tenant_id: &String,
+) -> Result<AccessToken, Box<dyn Error>> {
+    let refresh_token = AccessToken::new(refresh_token.secret().to_string());
+    let client = azure_core::new_http_client();
+    let tr = azure_identity::refresh_token::exchange(
+        client,
+        &*tenant_id,
+        client_id,
+        None,
+        &refresh_token,
+    )
+    .await?;
+    let refresh_token = RefreshToken::new(tr.refresh_token().secret().to_string());
+    let expires_in = std::time::Duration::from_secs(tr.expires_in());
+    store_access_token(
+        tr.access_token().to_owned(),
+        Some(expires_in),
+        Some(&refresh_token),
+        IdentityProvider::Azure,
+    )?;
+    Ok(tr.access_token().to_owned())
+}

--- a/src/auth/azure.rs
+++ b/src/auth/azure.rs
@@ -60,6 +60,7 @@ async fn azure_refresh_authorization(
     client_id: &ClientId,
     tenant_id: &String,
 ) -> Result<AccessToken, Box<dyn Error>> {
+    println!("Access Token expired. Attempting refresh...");
     let refresh_token = azure_core::auth::AccessToken::new(refresh_token.secret().to_string());
     let client = azure_core::new_http_client();
     let tr = azure_identity::refresh_token::exchange(

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,14 +38,13 @@ use arrow_flight::utils::flight_data_to_arrow_batch;
 use arrow_flight::{Criteria, FlightDescriptor, FlightInfo, Ticket};
 use clap::{Parser, Subcommand};
 use futures::StreamExt;
-use oauth2::AccessToken;
 use parquet::arrow::ArrowWriter;
 use parquet::basic::Compression;
 use parquet::file::properties::WriterProperties;
 use std::io::Write;
 use std::{fs, io};
 
-use crate::auth::{azure_authorization, IdentityProvider, OAuth2Interceptor};
+use crate::auth::{authorize, IdentityProvider, OAuth2Interceptor};
 use serde::{Deserialize, Serialize};
 use tonic::codegen::InterceptedService;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint, Identity};
@@ -423,20 +422,7 @@ async fn get_data(
 async fn connect_to_flight_server(
     config: &ConnectionConfig,
 ) -> Result<FlightServiceClient<InterceptedService<Channel, OAuth2Interceptor>>, Box<dyn Error>> {
-    let token = match config.identity_provider {
-        IdentityProvider::Azure => azure_authorization(config.scope.to_owned()).await?,
-        IdentityProvider::Google => {
-            return Err(Box::try_from(Status::unimplemented(
-                "Google Auth not yet implemented",
-            ))?)
-        }
-        IdentityProvider::Github => {
-            return Err(Box::try_from(Status::unimplemented(
-                "Github Auth not yet implemented",
-            ))?)
-        }
-        IdentityProvider::None => AccessToken::new("".parse()?),
-    };
+    let token = authorize(&config.identity_provider, &config.scope).await?;
     let channel = if config.tls {
         if let Some(tls_paths) = &config.tls_certs {
             let ca_cert = Certificate::from_pem(fs::read_to_string(&tls_paths.ca_crt)?);

--- a/src/main.rs
+++ b/src/main.rs
@@ -397,7 +397,7 @@ async fn get_data(
             while let Some(flight_data) = stream.message().await? {
                 let record_batch = flight_data_to_arrow_batch(
                     &flight_data,
-                    schema.clone(),
+                    Arc::clone(&schema),
                     &dictionaries_by_field,
                 )?;
 


### PR DESCRIPTION
This PR restructures Auth to make it more extensible, so that other auth services can be added more easily later.
It also adds support for storing and using refresh and access tokens with Azure.
When the Access Token expires, the Refresh Token will be exchanged for a new one, along with a new refresh token and automatically stored.

This allows for a seamless experience, where the user only has to hopefully use the browser login once, or if the Refresh Token expires. Though, if the refresh token does fail for whatever reason, it will ask the user to do browser auth.

This has now been tested. To test it yourself, set scope to "api://SERVICE_NAME/read".
In SERVICE_NAME, you'll need to add "api://SERVICE_NAME" as an extra audience, and set the App Reg Client ID to the one for app-SERVICE_NAMEDev. There probably should be a change in SERVICE_NAME to make it so that it's not hardcoded.

To test refresh token exchanging, on MacOS, go to Users//Library/Preferences/rs.flight-cli-auth/flight-cli-auth.toml and set the expires_on to a time in the past.

**PR and commits originally raised by Aidan**. This would resolve #3.

Note: This was rebased by Matt Phelps with the following: `git rebase --onto ossmain-refresh-token originmain originmain-refresh-token` where ossmain-refresh-token is current branch, originmain is internal 84.51 main branch, originmain-refresh-token is internal 84.51 feature branch.