### PR TITLE
Updated Dependencies & Bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 /target
 
 .env
+
+# For IntelliJ IDEA users
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,17 +30,17 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow = "20.0.0"
-arrow-flight = "20.0.0"
-azure_core = "0.4.0"
-azure_identity = "0.5.0"
+arrow = "26.0.0"
+arrow-flight = "26.0.0"
+azure_core = "0.6.0"
+azure_identity = "0.7.0"
 chrono = "0.4.20"
-clap = { version = "3.2.13", features = ["derive"] }
-confy = "0.4.0"
+clap = { version = "4.0.18", features = ["derive"] }
+confy = "0.5.1"
 futures = "0.3.21"
 http = "0.2.8"
 oauth2 = "4.2.3"
-parquet = { version = "20.0.0", features = ["async"] }
+parquet = { version = "26.0.0", features = ["async"] }
 serde = { version = "1.0.140", features = ["derive"] }
 tokio = { version = "1.20.0", features = ["tokio-macros", "net"] }
 tonic = { version = "0.8.0", features = ["tls", "tls-roots"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@
 
 [package]
 name = "flight-cli"
-version = "0.1.0"
+version = "0.1.1"
 license = "MIT License"
 description = "A Command Line Interface for Apache Arrow Flight"
 edition = "2021"

--- a/src/auth/azure.rs
+++ b/src/auth/azure.rs
@@ -44,7 +44,7 @@ async fn azure_browser_authorization(
     let code = development::naive_redirect_server(&c, 47471)?;
 
     // Exchange the token with one that can be used for authorization
-    let tr = c.exchange(code).await?;
+    let tr = c.exchange(azure_core::new_http_client(), code).await?;
     let access_token = AccessToken::new(tr.access_token().secret().to_string());
     store_access_token(
         &access_token,


### PR DESCRIPTION
Updated Dependencies and fixed breaking changes:
arrow = "20.0.0" -> "26.0.0"
arrow-flight = "20.0.0" -> "26.0.0"
azure_core = "0.4.0" -> "0.6.0"
azure_identity = "0.5.0" -> "0.7.0"
clap = "3.2.13" -> "4.0.18"
confy = "0.4.0" -> "0.5.1"
parquet = "20.0.0" -> "26.0.0"

This commit also fixes a bug causing the CLI to fail to connect to a flight server if an auth provider is not set.